### PR TITLE
[travis] Add workaround for missing libExampleIRTransforms.a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
 
  # TODO: Remove these hacky fixups
  - (cd $ROOT_PATH/lib && sudo ln -rsf libclang-cpp.so.1 libclang-cpp-$VERSION.so.1)
+ - sudo touch $ROOT_PATH/lib/libExampleIRTransforms.a
 
 script:
 # Build IWYU


### PR DESCRIPTION
CMake invocation fails with:

  CMake Error at /usr/lib/llvm-10/lib/cmake/llvm/LLVMExports.cmake:1350 (message):
    The imported target "ExampleIRTransforms" references the file

       "/usr/lib/llvm-10/lib/libExampleIRTransforms.a"

    but this file does not exist.

We don't use this library, so just placate CMake by making sure the file
exists.