### PR TITLE
iwyu_output: add using decl for dyn_cast

### DIFF
--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -54,6 +54,7 @@ using clang::SourceRange;
 using clang::TemplateDecl;
 using clang::UsingDecl;
 using llvm::cast;
+using llvm::dyn_cast;
 using llvm::errs;
 using llvm::isa;
 using llvm::raw_string_ostream;


### PR DESCRIPTION
Seems that's the style used elsewhere. Fixes this build error against
latest llvm-project.git:

/home/vmiklos/git/include-what-you-use/iwyu_output.cc: In function ‘bool include_what_you_use::internal::DeclCanBeForwardDeclared(const clang::Decl*, std::__cxx11::string*)’:
/home/vmiklos/git/include-what-you-use/iwyu_output.cc:727:35: error: ‘dyn_cast’ was not declared in this scope
   } else if (const auto* record = dyn_cast<RecordDecl>(decl)) {
                                   ^~~~~~~~
/home/vmiklos/git/include-what-you-use/iwyu_output.cc:727:35: note: suggested alternatives:
In file included from /home/vmiklos/git/llvm/instdir/include/clang/Basic/LLVM.h:21:0,
                 from /home/vmiklos/git/llvm/instdir/include/clang/AST/APValue.h:17,
                 from /home/vmiklos/git/llvm/instdir/include/clang/AST/Decl.h:16,
                 from /home/vmiklos/git/include-what-you-use/iwyu_output.h:27,
                 from /home/vmiklos/git/include-what-you-use/iwyu_output.cc:10:
/home/vmiklos/git/llvm/instdir/include/llvm/Support/Casting.h:342:61: note:   ‘llvm::dyn_cast’
 LLVM_NODISCARD inline typename cast_retty<X, Y *>::ret_type dyn_cast(Y *Val) {
                                                             ^~~~~~~~
/home/vmiklos/git/llvm/instdir/include/llvm/Support/Casting.h:332:5: note:   ‘llvm::dyn_cast’
     dyn_cast(const Y &Val) {
     ^~~~~~~~
/home/vmiklos/git/include-what-you-use/iwyu_output.cc:727:54: error: expected primary-expression before ‘>’ token
   } else if (const auto* record = dyn_cast<RecordDecl>(decl)) {
                                                      ^