### PR TITLE
Add explicit conversion from llvm::StringRef to std::string

### DIFF
--- a/iwyu_driver.cc
+++ b/iwyu_driver.cc
@@ -79,7 +79,7 @@ std::string GetExecutablePath(const char *Argv0) {
 }
 
 const char *SaveStringInSet(std::set<std::string> &SavedStrings, StringRef S) {
-  return SavedStrings.insert(S).first->c_str();
+  return SavedStrings.insert(S.str()).first->c_str();
 }
 
 void ExpandArgsFromBuf(const char *Arg,

--- a/iwyu_globals.cc
+++ b/iwyu_globals.cc
@@ -293,7 +293,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
   for (auto it = header_search->system_dir_begin();
        it != header_search->system_dir_end(); ++it) {
     if (const DirectoryEntry* entry = it->getDir()) {
-      const string path = NormalizeDirPath(MakeAbsolutePath(entry->getName()));
+      const string path = NormalizeDirPath(MakeAbsolutePath(entry->getName().str()));
       search_path_map[path] = HeaderSearchPath::kSystemPath;
     }
   }
@@ -303,7 +303,7 @@ static vector<HeaderSearchPath> ComputeHeaderSearchPaths(
       // search_dir_begin()/end() includes both system and user paths.
       // If it's a system path, it's already in the map, so everything
       // new is a user path.  The insert only 'takes' for new entries.
-      const string path = NormalizeDirPath(MakeAbsolutePath(entry->getName()));
+      const string path = NormalizeDirPath(MakeAbsolutePath(entry->getName().str()));
       search_path_map.insert(make_pair(path, HeaderSearchPath::kUserPath));
     }
   }

--- a/iwyu_lexer_utils.cc
+++ b/iwyu_lexer_utils.cc
@@ -70,7 +70,7 @@ SourceLocation GetLocationAfter(
 string GetIncludeNameAsWritten(
     SourceLocation include_loc,
     const CharacterDataGetterInterface& data_getter) {
-  const string data = GetSourceTextUntilEndOfLine(include_loc, data_getter);
+  const string data = GetSourceTextUntilEndOfLine(include_loc, data_getter).str();
   if (data.empty())
     return data;
   string::size_type endpos = string::npos;

--- a/iwyu_location_util.h
+++ b/iwyu_location_util.h
@@ -89,7 +89,7 @@ bool IsInScratchSpace(clang::SourceLocation loc);
 
 inline string GetFilePath(const clang::FileEntry* file) {
   return (IsBuiltinFile(file) ? "<built-in>" :
-          NormalizeFilePath(file->getName()));
+          NormalizeFilePath(file->getName().str()));
 }
 
 //------------------------------------------------------------

--- a/iwyu_output.cc
+++ b/iwyu_output.cc
@@ -168,7 +168,7 @@ string GetKindName(const clang::TagDecl* tag_decl) {
   if (const FakeNamedDecl* fake = FakeNamedDeclIfItIsOne(named_decl)) {
     return fake->kind_name();
   }
-  return tag_decl->getKindName();
+  return tag_decl->getKindName().str();
 }
 
 string GetQualifiedNameAsString(const clang::NamedDecl* named_decl) {

--- a/iwyu_path_util.cc
+++ b/iwyu_path_util.cc
@@ -134,7 +134,7 @@ string NormalizeFilePath(const string& path) {
   std::replace(normalized.begin(), normalized.end(), '\\', '/');
 #endif
 
-  return normalized.str();
+  return normalized.str().str();
 }
 
 string NormalizeDirPath(const string& path) {
@@ -154,14 +154,14 @@ string MakeAbsolutePath(const string& path) {
   std::error_code error = llvm::sys::fs::make_absolute(absolute_path);
   CHECK_(!error);
 
-  return absolute_path.str();
+  return absolute_path.str().str();
 }
 
 string MakeAbsolutePath(const string& base_path, const string& relative_path) {
   llvm::SmallString<128> absolute_path(base_path);
   llvm::sys::path::append(absolute_path, relative_path);
 
-  return absolute_path.str();
+  return absolute_path.str().str();
 }
 
 string GetParentPath(const string& path) {

--- a/iwyu_preprocessor.cc
+++ b/iwyu_preprocessor.cc
@@ -313,7 +313,7 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
       break;
     }
     const string filename = GetSourceTextUntilEndOfLine(current_loc,
-                                                        DefaultDataGetter());
+                                                        DefaultDataGetter()).str();
     // Use "" or <> based on where the file lives.
     string quoted_private_include;
     if (IsSystemIncludeFile(GetFilePath(current_loc)))
@@ -332,7 +332,7 @@ void IwyuPreprocessorInfo::ProcessHeadernameDirectivesInFile(
     }
 
     string after_text = GetSourceTextUntilEndOfLine(current_loc,
-                                                    DefaultDataGetter());
+                                                    DefaultDataGetter()).str();
     const string::size_type close_brace_pos = after_text.find('}');
     if (close_brace_pos == string::npos) {
       Warn(current_loc, "@headername directive missing a closing brace");


### PR DESCRIPTION
llvm/llvm-project@777180a makes the llvm::StringRef conversion operator
to std::string explicit.
These changes add a call to the str() method to perform the conversion.

Signed-off-by: Andrea Bocci <andrea.bocci@cern.ch>